### PR TITLE
Moves geth/tessera choice logic into binaryHelper, doesn't filter by …

### DIFF
--- a/src/generators/binaryHelper.js
+++ b/src/generators/binaryHelper.js
@@ -2,6 +2,7 @@ import { join } from 'path'
 import { libRootDir } from '../utils/fileUtils'
 import { executeSync } from '../utils/execUtils'
 import {
+  isBash,
   isDocker,
   isIstanbul,
   isTessera,
@@ -70,12 +71,23 @@ export function getGethOnPath() {
   return pathChoices
 }
 
-export function getDownloadableGethChoices() {
-  return getDownloadableChoices(BINARIES.quorum)
+export function getDownloadableGethChoices(deployment) {
+  let choices = getDownloadableChoices(BINARIES.quorum)
+  if (isBash(deployment)) {
+    choices = choices.concat(getGethOnPath())
+  }
+  return choices
 }
 
-export function getDownloadableTesseraChoices() {
-  return getDownloadableChoices(BINARIES.tessera)
+export function getDownloadableTesseraChoices(deployment) {
+  let choices = getDownloadableChoices(BINARIES.tessera)
+  if (isBash(deployment)) {
+    choices = choices.concat(getTesseraOnPath())
+  } else {
+    // allow all options in docker compose mode since local jdk version doesn't matter
+    choices = choices.map((choice) => ({ ...choice, disabled: false }))
+  }
+  return choices.concat('none')
 }
 
 function getDownloadableChoices(versions) {

--- a/src/generators/binaryHelper.test.js
+++ b/src/generators/binaryHelper.test.js
@@ -2,6 +2,7 @@ import { join } from 'path'
 import { any } from 'expect'
 import {
   downloadAndCopyBinaries,
+  getDownloadableTesseraChoices,
   getGethOnPath,
   getTesseraOnPath,
   pathToBootnode,
@@ -185,6 +186,29 @@ describe('Downloads binaries', () => {
     await downloadAndCopyBinaries(config)
     expect(downloadIfMissing).not.toBeCalledWith('quorum', '2.5.0')
     expect(downloadIfMissing).not.toBeCalledWith('tessera', '0.10.2')
+  })
+})
+
+describe('presents the correct binary options', () => {
+  it('disables 0.10.4 if in bash mode and on jdk 8', () => {
+    isJava11Plus.mockReturnValue(false)
+    const choices = getDownloadableTesseraChoices('bash')
+    expect(choices.some((choice) => choice.name === 'Tessera 0.10.4' && typeof choice.disabled === 'string')).toBeTruthy()
+    expect(choices.some((choice) => choice.name === 'Tessera 0.10.2' && choice.disabled === false)).toBeTruthy()
+    expect(choices.includes('none')).toBeTruthy()
+  })
+  it('disables 0.10.2 if in bash mode and on jdk 11+', () => {
+    isJava11Plus.mockReturnValue(true)
+    const choices = getDownloadableTesseraChoices('bash')
+    expect(choices.some((choice) => choice.name === 'Tessera 0.10.4' && choice.disabled === false)).toBeTruthy()
+    expect(choices.some((choice) => choice.name === 'Tessera 0.10.2' && typeof choice.disabled === 'string')).toBeTruthy()
+    expect(choices.includes('none')).toBeTruthy()
+  })
+  it('does not disable tessera options in docker mode', () => {
+    const choices = getDownloadableTesseraChoices('docker-compose')
+    expect(choices.some((choice) => choice.name === 'Tessera 0.10.4' && choice.disabled === false)).toBeTruthy()
+    expect(choices.some((choice) => choice.name === 'Tessera 0.10.2' && choice.disabled === false)).toBeTruthy()
+    expect(choices.includes('none')).toBeTruthy()
   })
 })
 

--- a/src/questions/questions.js
+++ b/src/questions/questions.js
@@ -6,11 +6,8 @@ import {
 import {
   getDownloadableGethChoices,
   getDownloadableTesseraChoices,
-  getGethOnPath,
-  getTesseraOnPath,
 } from '../generators/binaryHelper'
 import {
-  isBash,
   isRaft,
 } from '../model/NetworkConfig'
 
@@ -87,26 +84,14 @@ export const QUORUM_VERSION = {
   type: 'list',
   name: 'quorumVersion',
   message: 'Which version of Quorum would you like to use?',
-  choices: ({ deployment }) => {
-    let choices = [...getDownloadableGethChoices()]
-    if (isBash(deployment)) {
-      choices = choices.concat(getGethOnPath())
-    }
-    return choices
-  },
+  choices: ({ deployment }) => getDownloadableGethChoices(deployment),
 }
 
 export const TRANSACTION_MANAGER = {
   type: 'list',
   name: 'transactionManager',
   message: 'Choose a version of tessera if you would like to use private transactions in your network, otherwise choose "none"',
-  choices: ({ deployment }) => {
-    let choices = [...getDownloadableTesseraChoices()]
-    if (isBash(deployment)) {
-      choices = choices.concat(getTesseraOnPath())
-    }
-    return choices.concat('none')
-  },
+  choices: ({ deployment }) => getDownloadableTesseraChoices(deployment),
 }
 
 export const CAKESHOP = {


### PR DESCRIPTION
…jdk for docker, adds tests for tessera choices