### PR TITLE
Adds github actions badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+![](https://github.com/QuorumEngineering/quorum-creator/workflows/Build%20&%20Test/badge.svg)
 ## Developing 
 Clone this repo to your local machine.
 


### PR DESCRIPTION
If we change the name field of the action, it will change the text inside the badge. But we'll also need to change the url to match the new name