### PR TITLE
Updates istanbul tools to 1.0.2, bootnode to 1.9.7, uses constants fo…

### DIFF
--- a/src/generators/binaryHelper.js
+++ b/src/generators/binaryHelper.js
@@ -9,6 +9,8 @@ import {
 import {
   BINARIES,
   downloadIfMissing,
+  LATEST_BOOTNODE,
+  LATEST_ISTANBUL_TOOLS,
 } from './download'
 import { disableIfWrongJavaVersion } from '../questions/validators'
 import { info } from '../utils/log'
@@ -26,11 +28,11 @@ export async function downloadAndCopyBinaries(config) {
   const downloads = []
 
   if (isIstanbul(consensus)) {
-    downloads.push(downloadIfMissing('istanbul', '1.0.1'))
+    downloads.push(downloadIfMissing('istanbul', LATEST_ISTANBUL_TOOLS))
   }
 
   if (generateKeys) {
-    downloads.push(downloadIfMissing('bootnode', '1.8.27'))
+    downloads.push(downloadIfMissing('bootnode', LATEST_BOOTNODE))
   }
 
   if (quorumVersion !== 'PATH') {
@@ -130,11 +132,11 @@ export function pathToCakeshop(version) {
 }
 
 export function pathToIstanbulTools() {
-  const binary = BINARIES.istanbul['1.0.1']
-  return joinPath(wizardHomeDir(), 'bin', 'istanbul', '1.0.1', binary.name)
+  const binary = BINARIES.istanbul[LATEST_ISTANBUL_TOOLS]
+  return joinPath(wizardHomeDir(), 'bin', 'istanbul', LATEST_ISTANBUL_TOOLS, binary.name)
 }
 
 export function pathToBootnode() {
-  const binary = BINARIES.bootnode['1.8.27']
-  return joinPath(wizardHomeDir(), 'bin', 'bootnode', '1.8.27', binary.name)
+  const binary = BINARIES.bootnode[LATEST_BOOTNODE]
+  return joinPath(wizardHomeDir(), 'bin', 'bootnode', LATEST_BOOTNODE, binary.name)
 }

--- a/src/generators/binaryHelper.test.js
+++ b/src/generators/binaryHelper.test.js
@@ -26,7 +26,12 @@ import {
   TEST_WIZARD_HOME_DIR,
 } from '../utils/testHelper'
 import {
-  downloadIfMissing, LATEST_CAKESHOP, LATEST_QUORUM, LATEST_TESSERA, LATEST_TESSERA_J8,
+  downloadIfMissing,
+  LATEST_BOOTNODE,
+  LATEST_CAKESHOP,
+  LATEST_QUORUM,
+  LATEST_TESSERA,
+  LATEST_TESSERA_J8,
 } from './download'
 import { info } from '../utils/log'
 import { joinPath } from '../utils/pathUtils'
@@ -47,7 +52,7 @@ describe('Chooses the right paths to the binaries', () => {
     expect(pathToQuorumBinary('PATH')).toEqual('geth')
   })
   it('Calls geth binary in bin folder', () => {
-    expect(pathToQuorumBinary(LATEST_QUORUM)).toEqual(joinPath(wizardHomeDir(), 'bin/quorum/', LATEST_QUORUM, '/geth'))
+    expect(pathToQuorumBinary(LATEST_QUORUM)).toEqual(joinPath(wizardHomeDir(), 'bin/quorum', LATEST_QUORUM, 'geth'))
   })
   it('Calls tessera using $TESSERA_JAR', () => {
     expect(pathToTesseraJar('PATH')).toEqual('$TESSERA_JAR')
@@ -55,14 +60,14 @@ describe('Chooses the right paths to the binaries', () => {
   it('Calls tessera using bin folder jar', () => {
     expect(pathToTesseraJar(LATEST_TESSERA)).toEqual(joinPath(
       wizardHomeDir(),
-      'bin/tessera/', LATEST_TESSERA, '/tessera-app.jar',
+      'bin/tessera', LATEST_TESSERA, 'tessera-app.jar',
     ))
   })
   it('Calls cakeshop using bin folder war', () => {
-    expect(pathToCakeshop(LATEST_CAKESHOP)).toEqual(joinPath(wizardHomeDir(), 'bin/cakeshop/', LATEST_CAKESHOP, '/cakeshop.war'))
+    expect(pathToCakeshop(LATEST_CAKESHOP)).toEqual(joinPath(wizardHomeDir(), 'bin/cakeshop', LATEST_CAKESHOP, 'cakeshop.war'))
   })
   it('Calls bootnode using bin folder', () => {
-    expect(pathToBootnode()).toEqual(joinPath(wizardHomeDir(), 'bin/bootnode/1.8.27/bootnode'))
+    expect(pathToBootnode()).toEqual(joinPath(wizardHomeDir(), 'bin/bootnode', LATEST_BOOTNODE, 'bootnode'))
   })
 })
 

--- a/src/generators/download.js
+++ b/src/generators/download.js
@@ -84,6 +84,8 @@ export const LATEST_TESSERA = '0.10.5'
 export const LATEST_TESSERA_J8 = '0.10.2'
 export const LATEST_CAKESHOP = '0.11.0'
 export const LATEST_CAKESHOP_J8 = '0.11.0-J8'
+export const LATEST_ISTANBUL_TOOLS = '1.0.2'
+export const LATEST_BOOTNODE = '1.9.7'
 
 export const BINARIES = {
   quorum: {
@@ -150,11 +152,11 @@ export const BINARIES = {
   },
 
   istanbul: {
-    '1.0.1': {
+    '1.0.2': {
       name: 'istanbul',
       url: {
-        darwin: 'https://bintray.com/api/ui/download/quorumengineering/istanbul-tools/istanbul-tools_v1.0.1_darwin_amd64.tar.gz',
-        linux: 'https://bintray.com/api/ui/download/quorumengineering/istanbul-tools/istanbul-tools_v1.0.1_linux_amd64.tar.gz',
+        darwin: 'https://bintray.com/api/ui/download/quorumengineering/istanbul-tools/istanbul-tools_v1.0.2_darwin_amd64.tar.gz',
+        linux: 'https://bintray.com/api/ui/download/quorumengineering/istanbul-tools/istanbul-tools_v1.0.2_linux_amd64.tar.gz',
       },
       type: 'tar.gz',
       files: [
@@ -164,11 +166,11 @@ export const BINARIES = {
   },
 
   bootnode: {
-    '1.8.27': {
+    '1.9.7': {
       name: 'bootnode',
       url: {
-        darwin: 'https://bintray.com/api/ui/download/quorumengineering/geth-bootnode/bootnode_v1.8.27_darwin_amd64.tar.gz',
-        linux: 'https://bintray.com/api/ui/download/quorumengineering/geth-bootnode/bootnode_v1.8.27_linux_amd64.tar.gz',
+        darwin: 'https://bintray.com/api/ui/download/quorumengineering/geth-bootnode/bootnode_v1.9.7_darwin_amd64.tar.gz',
+        linux: 'https://bintray.com/api/ui/download/quorumengineering/geth-bootnode/bootnode_v1.9.7_linux_amd64.tar.gz',
       },
       type: 'tar.gz',
       files: [

--- a/src/generators/download.test.js
+++ b/src/generators/download.test.js
@@ -5,7 +5,10 @@ import {
 } from '../utils/testHelper'
 import {
   getPlatformSpecificUrl,
-  downloadIfMissing, LATEST_QUORUM, LATEST_TESSERA,
+  downloadIfMissing,
+  LATEST_QUORUM,
+  LATEST_TESSERA,
+  LATEST_ISTANBUL_TOOLS,
 } from './download'
 import {
   cwd,
@@ -66,7 +69,7 @@ const multiplePlatform = {
 describe('tests download if missing function', () => {
   it('istanbul that exists', () => {
     exists.mockReturnValue(true)
-    downloadIfMissing('istanbul', '1.0.1')
+    downloadIfMissing('istanbul', LATEST_ISTANBUL_TOOLS)
   })
   it('quorum that exists', () => {
     exists.mockReturnValue(true)


### PR DESCRIPTION
…r these values

Tested on mac and ubuntu. Instanbul + generate keys with both quorum 2.5.0 and 2.6.0