### PR TITLE
Changes cakeshop config to use docker container name as host in urls …

### DIFF
--- a/src/model/CakeshopConfig.js
+++ b/src/model/CakeshopConfig.js
@@ -11,19 +11,21 @@ export function generateCakeshopConfig(config) {
     const nodeData = {
       name: `node${i + 1}`,
       rpcUrl: isDocker(config.network.deployment)
-        ? `http://host.docker.internal:${node.quorum.rpcPort}`
+        // docker-compose creates dns entries for the container's ip using container name (nodeX)
+        ? `http://node${i + 1}:${config.containerPorts.quorum.rpcPort}`
         : `http://localhost:${node.quorum.rpcPort}`,
-      transactionManagerUrl: createTransactionManagerUrl(config, node),
+      transactionManagerUrl: createTransactionManagerUrl(config, node, i),
     }
     nodes.push(nodeData)
   })
   return nodes
 }
 
-function createTransactionManagerUrl(config, node) {
+function createTransactionManagerUrl(config, node, i) {
   if (isTessera(config.network.transactionManager)) {
     return isDocker(config.network.deployment)
-      ? `http://host.docker.internal:${node.tm.thirdPartyPort}`
+      // docker-compose creates dns entries for the container's ip using container name (txmanagerX)
+      ? `http://txmanager${i + 1}:${config.containerPorts.tm.thirdPartyPort}`
       : `http://localhost:${node.tm.thirdPartyPort}`
   }
   return ''

--- a/src/model/__snapshots__/CakeshopConfig.test.js.snap
+++ b/src/model/__snapshots__/CakeshopConfig.test.js.snap
@@ -44,17 +44,17 @@ exports[`creates 3nodes raft dockerFile no tessera cakeshop 1`] = `
 Array [
   Object {
     "name": "node1",
-    "rpcUrl": "http://host.docker.internal:22000",
+    "rpcUrl": "http://node1:8545",
     "transactionManagerUrl": "",
   },
   Object {
     "name": "node2",
-    "rpcUrl": "http://host.docker.internal:22001",
+    "rpcUrl": "http://node2:8545",
     "transactionManagerUrl": "",
   },
   Object {
     "name": "node3",
-    "rpcUrl": "http://host.docker.internal:22002",
+    "rpcUrl": "http://node3:8545",
     "transactionManagerUrl": "",
   },
 ]
@@ -64,18 +64,18 @@ exports[`creates 3nodes raft dockerFile tessera cakeshop 1`] = `
 Array [
   Object {
     "name": "node1",
-    "rpcUrl": "http://host.docker.internal:22000",
-    "transactionManagerUrl": "http://host.docker.internal:9081",
+    "rpcUrl": "http://node1:8545",
+    "transactionManagerUrl": "http://txmanager1:9080",
   },
   Object {
     "name": "node2",
-    "rpcUrl": "http://host.docker.internal:22001",
-    "transactionManagerUrl": "http://host.docker.internal:9082",
+    "rpcUrl": "http://node2:8545",
+    "transactionManagerUrl": "http://txmanager2:9080",
   },
   Object {
     "name": "node3",
-    "rpcUrl": "http://host.docker.internal:22002",
-    "transactionManagerUrl": "http://host.docker.internal:9083",
+    "rpcUrl": "http://node3:8545",
+    "transactionManagerUrl": "http://txmanager3:9080",
   },
 ]
 `;


### PR DESCRIPTION
…(host.docker.internal only works on windows and mac)

Docker compose creates host entries for the container name, so http://node1:8545 will successfully hit node1's ip from any container in the network.