### PR TITLE
Minor fixes

### DIFF
--- a/lib/docker-compose-definitions-quorum.yml
+++ b/lib/docker-compose-definitions-quorum.yml
@@ -48,7 +48,7 @@ x-quorum-def:
       NETWORK_ID=$$(cat $${GENESIS_FILE} | grep chainId | awk -F " " '{print $$2}' | awk -F "," '{print $$1}')
       GETH_ARGS_raft="--raft --raftport ${QUORUM_RAFT_PORT:-50400}"
       GETH_ARGS_istanbul="--emitcheckpoints --istanbul.blockperiod 1 --mine --minerthreads 1 --syncmode full"
-      EXTRA_ARGS=${QUORUM_GETH_ARGS:-}
+      EXTRA_ARGS="${QUORUM_GETH_ARGS:-}"
       geth --datadir $${DDIR} init $${GENESIS_FILE}
       geth \
         --identity node$${NODE_ID}-${QUORUM_CONSENSUS:-istanbul} \

--- a/lib/docker-compose-definitions-quorum.yml
+++ b/lib/docker-compose-definitions-quorum.yml
@@ -29,7 +29,7 @@ x-quorum-def:
       do
         set -e
         if [ -S $${PRIVATE_CONFIG} ] && \
-          [ "I'm up!" == "$$(wget --timeout $${UDS_WAIT} -qO- --proxy off ${DOCKER_IP}$${NODE_ID}:${TESSERA_P2P_PORT:-9000}/upcheck)" ];
+          [ "I'm up!" == "$$(wget --timeout $${UDS_WAIT} -qO- --proxy off txmanager$${NODE_ID}:${TESSERA_P2P_PORT:-9000}/upcheck)" ];
         then break
         else
           echo "Sleep $${UDS_WAIT} seconds. Waiting for TxManager."

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "quorum-wizard",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1286,6 +1286,382 @@
         "colorspace": "1.1.x",
         "enabled": "2.0.x",
         "kuler": "^2.0.0"
+      }
+    },
+    "@ethersproject/abi": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.2.tgz",
+      "integrity": "sha512-Z+5f7xOgtRLu/W2l9Ry5xF7ehh9QVQ0m1vhynmTcS7DMfHgqTd1/PDFC62aw91ZPRCRZsYdZJu8ymokC5e1JSw==",
+      "requires": {
+        "@ethersproject/address": "^5.0.0",
+        "@ethersproject/bignumber": "^5.0.0",
+        "@ethersproject/bytes": "^5.0.0",
+        "@ethersproject/constants": "^5.0.0",
+        "@ethersproject/hash": "^5.0.0",
+        "@ethersproject/keccak256": "^5.0.0",
+        "@ethersproject/logger": "^5.0.0",
+        "@ethersproject/properties": "^5.0.0",
+        "@ethersproject/strings": "^5.0.0"
+      }
+    },
+    "@ethersproject/abstract-provider": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.0.2.tgz",
+      "integrity": "sha512-U1s60+nG02x8FKNMoVNI6MG8SguWCoG9HJtwOqWZ38LBRMsDV4c0w4izKx98kcsN3wXw4U2/YAyJ9LlH7+/hkg==",
+      "requires": {
+        "@ethersproject/bignumber": "^5.0.0",
+        "@ethersproject/bytes": "^5.0.0",
+        "@ethersproject/logger": "^5.0.0",
+        "@ethersproject/networks": "^5.0.0",
+        "@ethersproject/properties": "^5.0.0",
+        "@ethersproject/transactions": "^5.0.0",
+        "@ethersproject/web": "^5.0.0"
+      }
+    },
+    "@ethersproject/abstract-signer": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.0.2.tgz",
+      "integrity": "sha512-CzzXbeqKlgayE4YTnvvreGBG3n+HxakGXrxaGM6LjBZnOOIVSYi6HMFG8ZXls7UspRY4hvMrtnKEJKDCOngSBw==",
+      "requires": {
+        "@ethersproject/abstract-provider": "^5.0.0",
+        "@ethersproject/bignumber": "^5.0.0",
+        "@ethersproject/bytes": "^5.0.0",
+        "@ethersproject/logger": "^5.0.0",
+        "@ethersproject/properties": "^5.0.0"
+      }
+    },
+    "@ethersproject/address": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.2.tgz",
+      "integrity": "sha512-+rz26RKj7ujGfQynys4V9VJRbR+wpC6eL8F22q3raWMH3152Ha31GwJPWzxE/bEA+43M/zTNVwY0R53gn53L2Q==",
+      "requires": {
+        "@ethersproject/bignumber": "^5.0.0",
+        "@ethersproject/bytes": "^5.0.0",
+        "@ethersproject/keccak256": "^5.0.0",
+        "@ethersproject/logger": "^5.0.0",
+        "@ethersproject/rlp": "^5.0.0",
+        "bn.js": "^4.4.0"
+      }
+    },
+    "@ethersproject/base64": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.0.2.tgz",
+      "integrity": "sha512-0FE5RH5cUDddOiQEDpWtyHjkSW4D5/rdJzA3KTZo8Fk5ab/Y8vdzqbamsXPyPsXU3gS+zCE5Qq4EKVOWlWLLTA==",
+      "requires": {
+        "@ethersproject/bytes": "^5.0.0"
+      }
+    },
+    "@ethersproject/basex": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.0.2.tgz",
+      "integrity": "sha512-p4m2CeQqI9vma3XipRbP2iDf6zTsbroE0MEXBAYXidsoJQSvePKrC6MVRKfTzfcHej1b9wfmjVBzqhqn3FRhIA==",
+      "requires": {
+        "@ethersproject/bytes": "^5.0.0",
+        "@ethersproject/properties": "^5.0.0"
+      }
+    },
+    "@ethersproject/bignumber": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.5.tgz",
+      "integrity": "sha512-24ln7PV0g8ZzjcVZiLW9Wod0i+XCmK6zKkAaxw5enraTIT1p7gVOcSXFSzNQ9WYAwtiFQPvvA+TIO2oEITZNJA==",
+      "requires": {
+        "@ethersproject/bytes": "^5.0.0",
+        "@ethersproject/logger": "^5.0.0",
+        "bn.js": "^4.4.0"
+      }
+    },
+    "@ethersproject/bytes": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.3.tgz",
+      "integrity": "sha512-AyPMAlY+Amaw4Zfp8OAivm1xYPI8mqiUYmEnSUk1CnS2NrQGHEMmFJFiOJdS3gDDpgSOFhWIjZwxKq2VZpqNTA==",
+      "requires": {
+        "@ethersproject/logger": "^5.0.0"
+      }
+    },
+    "@ethersproject/constants": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.2.tgz",
+      "integrity": "sha512-nNoVlNP6bgpog7pQ2EyD1xjlaXcy1Cl4kK5v1KoskHj58EtB6TK8M8AFGi3GgHTdMldfT4eN3OsoQ/CdOTVNFA==",
+      "requires": {
+        "@ethersproject/bignumber": "^5.0.0"
+      }
+    },
+    "@ethersproject/contracts": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.0.2.tgz",
+      "integrity": "sha512-Ud3oW8mBNIWE+WHRjvwVEwfvshn7lfYWSSKG0fPSb6baRN9mLOoNguX+VIv3W5Sne9w2utnBmxLF2ESXitw64A==",
+      "requires": {
+        "@ethersproject/abi": "^5.0.0",
+        "@ethersproject/abstract-provider": "^5.0.0",
+        "@ethersproject/abstract-signer": "^5.0.0",
+        "@ethersproject/address": "^5.0.0",
+        "@ethersproject/bignumber": "^5.0.0",
+        "@ethersproject/bytes": "^5.0.0",
+        "@ethersproject/constants": "^5.0.0",
+        "@ethersproject/logger": "^5.0.0",
+        "@ethersproject/properties": "^5.0.0"
+      }
+    },
+    "@ethersproject/hash": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.2.tgz",
+      "integrity": "sha512-dWGvNwmVRX2bxoQQ3ciMw46Vzl1nqfL+5R8+2ZxsRXD3Cjgw1dL2mdjJF7xMMWPvPdrlhKXWSK0gb8VLwHZ8Cw==",
+      "requires": {
+        "@ethersproject/bytes": "^5.0.0",
+        "@ethersproject/keccak256": "^5.0.0",
+        "@ethersproject/logger": "^5.0.0",
+        "@ethersproject/strings": "^5.0.0"
+      }
+    },
+    "@ethersproject/hdnode": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.0.2.tgz",
+      "integrity": "sha512-QAUI5tfseTFqv00Vnbwzofqse81wN9TaL+x5GufTHIHJXgVdguxU+l39E3VYDCmO+eVAA6RCn5dJgeyra+PU2g==",
+      "requires": {
+        "@ethersproject/abstract-signer": "^5.0.0",
+        "@ethersproject/basex": "^5.0.0",
+        "@ethersproject/bignumber": "^5.0.0",
+        "@ethersproject/bytes": "^5.0.0",
+        "@ethersproject/logger": "^5.0.0",
+        "@ethersproject/pbkdf2": "^5.0.0",
+        "@ethersproject/properties": "^5.0.0",
+        "@ethersproject/sha2": "^5.0.0",
+        "@ethersproject/signing-key": "^5.0.0",
+        "@ethersproject/strings": "^5.0.0",
+        "@ethersproject/transactions": "^5.0.0",
+        "@ethersproject/wordlists": "^5.0.0"
+      }
+    },
+    "@ethersproject/json-wallets": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.0.3.tgz",
+      "integrity": "sha512-VfDXn5ylugkfiM6SrvQfhX9oAHVU5dsNpRw8PjjTCn4k5E2JuVRO5A8sibkYXDhcBmRISZIWqclIxka6FI/chg==",
+      "requires": {
+        "@ethersproject/abstract-signer": "^5.0.0",
+        "@ethersproject/address": "^5.0.0",
+        "@ethersproject/bytes": "^5.0.0",
+        "@ethersproject/hdnode": "^5.0.0",
+        "@ethersproject/keccak256": "^5.0.0",
+        "@ethersproject/logger": "^5.0.0",
+        "@ethersproject/pbkdf2": "^5.0.0",
+        "@ethersproject/properties": "^5.0.0",
+        "@ethersproject/random": "^5.0.0",
+        "@ethersproject/strings": "^5.0.0",
+        "@ethersproject/transactions": "^5.0.0",
+        "aes-js": "3.0.0",
+        "scrypt-js": "3.0.1"
+      }
+    },
+    "@ethersproject/keccak256": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.2.tgz",
+      "integrity": "sha512-MbroXutc0gPNYIrUjS4Aw0lDuXabdzI7+l7elRWr1G6G+W0v00e/3gbikWkCReGtt2Jnt4lQSgnflhDwQGcIhA==",
+      "requires": {
+        "@ethersproject/bytes": "^5.0.0",
+        "js-sha3": "0.5.7"
+      }
+    },
+    "@ethersproject/logger": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.4.tgz",
+      "integrity": "sha512-alA2LiAy1LdQ/L1SA9ajUC7MvGAEQLsICEfKK4erX5qhkXE1LwLSPIzobtOWFsMHf2yrXGKBLnnpuVHprI3sAw=="
+    },
+    "@ethersproject/networks": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.0.2.tgz",
+      "integrity": "sha512-T7HVd62D4izNU2tDHf6xUDo7k4JOGX4Lk7vDmVcDKrepSWwL2OmGWrqSlkRe2a1Dnz4+1VPE6fb6+KsmSRe82g==",
+      "requires": {
+        "@ethersproject/logger": "^5.0.0"
+      }
+    },
+    "@ethersproject/pbkdf2": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.0.2.tgz",
+      "integrity": "sha512-OJFxdX/VtGI5M04lAzXKEOb76XBzjCOzGyko3/bMWat3ePAw7RveBOLyhm79SBs2fh21MSYgdG6JScEMHoSImw==",
+      "requires": {
+        "@ethersproject/bytes": "^5.0.0",
+        "@ethersproject/sha2": "^5.0.0"
+      }
+    },
+    "@ethersproject/properties": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.2.tgz",
+      "integrity": "sha512-FxAisPGAOACQjMJzewl9OJG6lsGCPTm5vpUMtfeoxzAlAb2lv+kHzQPUh9h4jfAILzE8AR1jgXMzRmlhwyra1Q==",
+      "requires": {
+        "@ethersproject/logger": "^5.0.0"
+      }
+    },
+    "@ethersproject/providers": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.0.5.tgz",
+      "integrity": "sha512-ZR3yFg/m8qDl7317yXOHE7tKeGfoyZIZ/imhVC4JqAH+SX1rb6bdZcSjhJfet7rLmnJSsnYLTgIiVIT85aVLgg==",
+      "requires": {
+        "@ethersproject/abstract-provider": "^5.0.0",
+        "@ethersproject/abstract-signer": "^5.0.0",
+        "@ethersproject/address": "^5.0.0",
+        "@ethersproject/bignumber": "^5.0.0",
+        "@ethersproject/bytes": "^5.0.0",
+        "@ethersproject/constants": "^5.0.0",
+        "@ethersproject/hash": "^5.0.0",
+        "@ethersproject/logger": "^5.0.0",
+        "@ethersproject/networks": "^5.0.0",
+        "@ethersproject/properties": "^5.0.0",
+        "@ethersproject/random": "^5.0.0",
+        "@ethersproject/rlp": "^5.0.0",
+        "@ethersproject/strings": "^5.0.0",
+        "@ethersproject/transactions": "^5.0.0",
+        "@ethersproject/web": "^5.0.0",
+        "ws": "7.2.3"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.3.tgz",
+          "integrity": "sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ=="
+        }
+      }
+    },
+    "@ethersproject/random": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.0.2.tgz",
+      "integrity": "sha512-kLeS+6bwz37WR2zbe69gudyoGVoUzljQO0LhifnATsZ7rW0JZ9Zgt0h5aXY7tqFDo9TvdqeCwUFdp1t3T5Fkhg==",
+      "requires": {
+        "@ethersproject/bytes": "^5.0.0",
+        "@ethersproject/logger": "^5.0.0"
+      }
+    },
+    "@ethersproject/rlp": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.2.tgz",
+      "integrity": "sha512-oE0M5jqQ67fi2SuMcrpoewOpEuoXaD8M9JeR9md1bXRMvDYgKXUtDHs22oevpEOdnO2DPIRabp6MVHa4aDuWmw==",
+      "requires": {
+        "@ethersproject/bytes": "^5.0.0",
+        "@ethersproject/logger": "^5.0.0"
+      }
+    },
+    "@ethersproject/sha2": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.0.2.tgz",
+      "integrity": "sha512-VFl4qSStjQZaygpqoAHswaCY59qBm1Sm0rf8iv0tmgVsRf0pBg2nJaNf9NXXvcuJ9AYPyXl57dN8kozdC4z5Cg==",
+      "requires": {
+        "@ethersproject/bytes": "^5.0.0",
+        "@ethersproject/logger": "^5.0.0",
+        "hash.js": "1.1.3"
+      },
+      "dependencies": {
+        "hash.js": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.0"
+          }
+        }
+      }
+    },
+    "@ethersproject/signing-key": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.0.3.tgz",
+      "integrity": "sha512-5QPZaBRGCLzfVMbFb3LcVjNR0UbTXnwDHASnQYfbzwUOnFYHKxHsrcbl/5ONGoppgi8yXgOocKqlPCFycJJVWQ==",
+      "requires": {
+        "@ethersproject/bytes": "^5.0.0",
+        "@ethersproject/logger": "^5.0.0",
+        "@ethersproject/properties": "^5.0.0",
+        "elliptic": "6.5.3"
+      }
+    },
+    "@ethersproject/solidity": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.0.2.tgz",
+      "integrity": "sha512-RygurUe1hPW1LDYAPXy4471AklGWNnxgFWc3YUE6H11gzkit26jr6AyZH4Yyjw38eBBL6j0AOfQzMWm+NhxZ9g==",
+      "requires": {
+        "@ethersproject/bignumber": "^5.0.0",
+        "@ethersproject/bytes": "^5.0.0",
+        "@ethersproject/keccak256": "^5.0.0",
+        "@ethersproject/sha2": "^5.0.0",
+        "@ethersproject/strings": "^5.0.0"
+      }
+    },
+    "@ethersproject/strings": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.2.tgz",
+      "integrity": "sha512-oNa+xvSqsFU96ndzog0IBTtsRFGOqGpzrXJ7shXLBT7juVeSEyZA/sYs0DMZB5mJ9FEjHdZKxR/rTyBY91vuXg==",
+      "requires": {
+        "@ethersproject/bytes": "^5.0.0",
+        "@ethersproject/constants": "^5.0.0",
+        "@ethersproject/logger": "^5.0.0"
+      }
+    },
+    "@ethersproject/transactions": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.2.tgz",
+      "integrity": "sha512-jZp0ZbbJlq4JLZY6qoMzNtp2HQsX6USQposi3ns0MPUdn3OdZJBDtrcO15r/2VS5t/K1e1GE5MI1HmMKlcTbbQ==",
+      "requires": {
+        "@ethersproject/address": "^5.0.0",
+        "@ethersproject/bignumber": "^5.0.0",
+        "@ethersproject/bytes": "^5.0.0",
+        "@ethersproject/constants": "^5.0.0",
+        "@ethersproject/keccak256": "^5.0.0",
+        "@ethersproject/logger": "^5.0.0",
+        "@ethersproject/properties": "^5.0.0",
+        "@ethersproject/rlp": "^5.0.0",
+        "@ethersproject/signing-key": "^5.0.0"
+      }
+    },
+    "@ethersproject/units": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.0.2.tgz",
+      "integrity": "sha512-PSuzycBA1zmRysTtKtp+XYZ3HIJfbmfRdZchOUxdyeGo5siUi9H6mYQcxdJHv82oKp/FniMj8qS8qtLQThhOEg==",
+      "requires": {
+        "@ethersproject/bignumber": "^5.0.0",
+        "@ethersproject/constants": "^5.0.0",
+        "@ethersproject/logger": "^5.0.0"
+      }
+    },
+    "@ethersproject/wallet": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.0.2.tgz",
+      "integrity": "sha512-gg86ynLV5k5caNnYpJoYc6WyIUHKMTjOITCk5zXGyVbbkXE07y/fGql4A51W0C6mWkeb5Mzz8AKqzHZECdH30w==",
+      "requires": {
+        "@ethersproject/abstract-provider": "^5.0.0",
+        "@ethersproject/abstract-signer": "^5.0.0",
+        "@ethersproject/address": "^5.0.0",
+        "@ethersproject/bignumber": "^5.0.0",
+        "@ethersproject/bytes": "^5.0.0",
+        "@ethersproject/hash": "^5.0.0",
+        "@ethersproject/hdnode": "^5.0.0",
+        "@ethersproject/json-wallets": "^5.0.0",
+        "@ethersproject/keccak256": "^5.0.0",
+        "@ethersproject/logger": "^5.0.0",
+        "@ethersproject/properties": "^5.0.0",
+        "@ethersproject/random": "^5.0.0",
+        "@ethersproject/signing-key": "^5.0.0",
+        "@ethersproject/transactions": "^5.0.0",
+        "@ethersproject/wordlists": "^5.0.0"
+      }
+    },
+    "@ethersproject/web": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.0.2.tgz",
+      "integrity": "sha512-uAlcxdrAWB9PXZlb5NPzbOOt5/m9EJP2c6eLw15/PXPkNNohEIKvdXXOWdcQgTjZ0pcAaD/9mnJ6HXg7NbqXiw==",
+      "requires": {
+        "@ethersproject/base64": "^5.0.0",
+        "@ethersproject/logger": "^5.0.0",
+        "@ethersproject/properties": "^5.0.0",
+        "@ethersproject/strings": "^5.0.0"
+      }
+    },
+    "@ethersproject/wordlists": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.0.2.tgz",
+      "integrity": "sha512-6vKDQcjjpnfdSCr0+jNxpFH3ieKxUPkm29tQX2US7a3zT/sJU/BGlKBR7D8oOpwdE0hpkHhJyMlypRBK+A2avA==",
+      "requires": {
+        "@ethersproject/bytes": "^5.0.0",
+        "@ethersproject/hash": "^5.0.0",
+        "@ethersproject/logger": "^5.0.0",
+        "@ethersproject/properties": "^5.0.0",
+        "@ethersproject/strings": "^5.0.0"
       }
     },
     "@istanbuljs/load-nyc-config": {
@@ -3288,9 +3664,9 @@
       "dev": true
     },
     "elliptic": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
-      "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
       "requires": {
         "bn.js": "^4.4.0",
         "brorand": "^1.0.1",
@@ -3796,19 +4172,39 @@
       "dev": true
     },
     "ethers": {
-      "version": "4.0.47",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.47.tgz",
-      "integrity": "sha512-hssRYhngV4hiDNeZmVU/k5/E8xmLG8UpcNUzg6mb7lqhgpFPH/t7nuv20RjRrEf0gblzvi2XwR5Te+V3ZFc9pQ==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.0.7.tgz",
+      "integrity": "sha512-1Zu9s+z4BgsDAZcGIYACJdWBB6mVtCCmUonj68Njul7STcSdgwOyj0sCAxCUr2Nsmsamckr4E12q3ecvZPGAUw==",
       "requires": {
-        "aes-js": "3.0.0",
-        "bn.js": "^4.4.0",
-        "elliptic": "6.5.2",
-        "hash.js": "1.1.3",
-        "js-sha3": "0.5.7",
-        "scrypt-js": "2.0.4",
-        "setimmediate": "1.0.4",
-        "uuid": "2.0.1",
-        "xmlhttprequest": "1.8.0"
+        "@ethersproject/abi": "^5.0.0",
+        "@ethersproject/abstract-provider": "^5.0.0",
+        "@ethersproject/abstract-signer": "^5.0.0",
+        "@ethersproject/address": "^5.0.0",
+        "@ethersproject/base64": "^5.0.0",
+        "@ethersproject/bignumber": "^5.0.0",
+        "@ethersproject/bytes": "^5.0.0",
+        "@ethersproject/constants": "^5.0.0",
+        "@ethersproject/contracts": "^5.0.0",
+        "@ethersproject/hash": "^5.0.0",
+        "@ethersproject/hdnode": "^5.0.0",
+        "@ethersproject/json-wallets": "^5.0.0",
+        "@ethersproject/keccak256": "^5.0.0",
+        "@ethersproject/logger": "^5.0.0",
+        "@ethersproject/networks": "^5.0.0",
+        "@ethersproject/pbkdf2": "^5.0.0",
+        "@ethersproject/properties": "^5.0.0",
+        "@ethersproject/providers": "^5.0.0",
+        "@ethersproject/random": "^5.0.0",
+        "@ethersproject/rlp": "^5.0.0",
+        "@ethersproject/sha2": "^5.0.0",
+        "@ethersproject/signing-key": "^5.0.0",
+        "@ethersproject/solidity": "^5.0.0",
+        "@ethersproject/strings": "^5.0.0",
+        "@ethersproject/transactions": "^5.0.0",
+        "@ethersproject/units": "^5.0.0",
+        "@ethersproject/wallet": "^5.0.0",
+        "@ethersproject/web": "^5.0.0",
+        "@ethersproject/wordlists": "^5.0.0"
       }
     },
     "exec-sh": {
@@ -4403,12 +4799,12 @@
       }
     },
     "hash.js": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
-      "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
       "requires": {
         "inherits": "^2.0.3",
-        "minimalistic-assert": "^1.0.0"
+        "minimalistic-assert": "^1.0.1"
       }
     },
     "hmac-drbg": {
@@ -7808,9 +8204,9 @@
       }
     },
     "scrypt-js": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
-      "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
+      "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
     },
     "semver": {
       "version": "5.7.1",
@@ -7850,11 +8246,6 @@
           }
         }
       }
-    },
-    "setimmediate": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
-      "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48="
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -8774,11 +9165,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
-    "uuid": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
-      "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
-    },
     "v8-compile-cache": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
@@ -9013,11 +9399,6 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
-    },
-    "xmlhttprequest": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
-      "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw="
     },
     "xregexp": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@babel/runtime": "^7.8.3",
     "axios": "^0.19.2",
-    "ethers": "^4.0.0",
+    "ethers": "^5.0.7",
     "fs-extra": "^9.0.0",
     "inquirer": "^7.0.0",
     "ip-address": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quorum-wizard",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Tool for walking through the setup of networks.",
   "main": "src/index.js",
   "bin": {

--- a/src/generators/dockerHelper.js
+++ b/src/generators/dockerHelper.js
@@ -101,7 +101,7 @@ TESSERA_3PARTY_PORT=${config.containerPorts.tm.thirdPartyPort}`)
   }
   if (isQuorum260Plus(config.network.quorumVersion)) {
     env = env.concat(`
-QUORUM_GETH_ARGS="--allow-insecure-unlock --graphql --graphql.port ${config.containerPorts.quorum.graphQlPort} --graphql.corsdomain=* --graphql.addr=0.0.0.0"`)
+QUORUM_GETH_ARGS=--allow-insecure-unlock --graphql --graphql.port ${config.containerPorts.quorum.graphQlPort} --graphql.corsdomain=* --graphql.addr=0.0.0.0`)
   }
   if (getDockerRegistry() !== '') {
     env = env.concat(`

--- a/src/generators/networkCreator.js
+++ b/src/generators/networkCreator.js
@@ -18,7 +18,7 @@ import { buildKubernetesResource, LATEST_QUBERNETES } from '../model/ResourceCon
 import {
   isBash, isDocker, isKubernetes, isRaft, isTessera,
 } from '../model/NetworkConfig'
-import { joinPath } from '../utils/pathUtils'
+import { joinPath, unixifyPath } from '../utils/pathUtils'
 import { executeSync } from '../utils/execUtils'
 import { info, error } from '../utils/log'
 import { buildDockerIp } from '../utils/subnetUtils'
@@ -40,15 +40,18 @@ export function generateResourcesRemote(config) {
   const remoteOutputDir = joinPath(networkPath, 'out', 'config')
 
   const file = buildKubernetesResource(config)
-  writeFile(joinPath(networkPath, 'qubernetes.yaml'), file, false)
+  const qubernetesYamlPath = joinPath(networkPath, 'qubernetes.yaml')
+  writeFile(qubernetesYamlPath, file, false)
 
   const initScript = isKubernetes(config.network.deployment) ? 'qube-init' : 'quorum-init'
   const copy7nodes = !config.network.generateKeys ? 'cp -r /qubernetes/7nodes /qubernetes/out/config; ' : ''
   const qubernetesImage = `${getDockerRegistry()}quorumengineering/qubernetes:${LATEST_QUBERNETES}`
+  const outPath = joinPath(networkPath, 'out')
   const dockerCommands = [
     `cd ${networkPath}`,
     `docker pull ${qubernetesImage}`,
-    `docker run --rm -v ${joinPath(networkPath, 'qubernetes.yaml')}:/qubernetes/qubernetes.yaml -v ${joinPath(networkPath, 'out')}:/qubernetes/out ${qubernetesImage} /bin/bash -c "${copy7nodes}./${initScript} --action=update qubernetes.yaml"`,
+    // docker volumes using C:\folder\ style paths can cause problems, convert to /c/folder/ on windows
+    `docker run --rm -v ${unixifyPath(qubernetesYamlPath)}:/qubernetes/qubernetes.yaml -v ${unixifyPath(outPath)}:/qubernetes/out ${qubernetesImage} /bin/bash -c "${copy7nodes}./${initScript} --action=update qubernetes.yaml"`,
   ]
 
   try {

--- a/src/model/__snapshots__/DockerFile.test.js.snap
+++ b/src/model/__snapshots__/DockerFile.test.js.snap
@@ -32,7 +32,7 @@ x-quorum-def:
       do
         set -e
         if [ -S $\${PRIVATE_CONFIG} ] && \\\\
-          [ \\"I'm up!\\" == \\"$$(wget --timeout $\${UDS_WAIT} -qO- --proxy off \${DOCKER_IP}$\${NODE_ID}:\${TESSERA_P2P_PORT:-9000}/upcheck)\\" ];
+          [ \\"I'm up!\\" == \\"$$(wget --timeout $\${UDS_WAIT} -qO- --proxy off txmanager$\${NODE_ID}:\${TESSERA_P2P_PORT:-9000}/upcheck)\\" ];
         then break
         else
           echo \\"Sleep $\${UDS_WAIT} seconds. Waiting for TxManager.\\"
@@ -51,7 +51,7 @@ x-quorum-def:
       NETWORK_ID=$$(cat $\${GENESIS_FILE} | grep chainId | awk -F \\" \\" '{print $$2}' | awk -F \\",\\" '{print $$1}')
       GETH_ARGS_raft=\\"--raft --raftport \${QUORUM_RAFT_PORT:-50400}\\"
       GETH_ARGS_istanbul=\\"--emitcheckpoints --istanbul.blockperiod 1 --mine --minerthreads 1 --syncmode full\\"
-      EXTRA_ARGS=\${QUORUM_GETH_ARGS:-}
+      EXTRA_ARGS=\\"\${QUORUM_GETH_ARGS:-}\\"
       geth --datadir $\${DDIR} init $\${GENESIS_FILE}
       geth \\\\
         --identity node$\${NODE_ID}-\${QUORUM_CONSENSUS:-istanbul} \\\\
@@ -279,7 +279,7 @@ x-quorum-def:
       do
         set -e
         if [ -S $\${PRIVATE_CONFIG} ] && \\\\
-          [ \\"I'm up!\\" == \\"$$(wget --timeout $\${UDS_WAIT} -qO- --proxy off \${DOCKER_IP}$\${NODE_ID}:\${TESSERA_P2P_PORT:-9000}/upcheck)\\" ];
+          [ \\"I'm up!\\" == \\"$$(wget --timeout $\${UDS_WAIT} -qO- --proxy off txmanager$\${NODE_ID}:\${TESSERA_P2P_PORT:-9000}/upcheck)\\" ];
         then break
         else
           echo \\"Sleep $\${UDS_WAIT} seconds. Waiting for TxManager.\\"
@@ -298,7 +298,7 @@ x-quorum-def:
       NETWORK_ID=$$(cat $\${GENESIS_FILE} | grep chainId | awk -F \\" \\" '{print $$2}' | awk -F \\",\\" '{print $$1}')
       GETH_ARGS_raft=\\"--raft --raftport \${QUORUM_RAFT_PORT:-50400}\\"
       GETH_ARGS_istanbul=\\"--emitcheckpoints --istanbul.blockperiod 1 --mine --minerthreads 1 --syncmode full\\"
-      EXTRA_ARGS=\${QUORUM_GETH_ARGS:-}
+      EXTRA_ARGS=\\"\${QUORUM_GETH_ARGS:-}\\"
       geth --datadir $\${DDIR} init $\${GENESIS_FILE}
       geth \\\\
         --identity node$\${NODE_ID}-\${QUORUM_CONSENSUS:-istanbul} \\\\
@@ -523,7 +523,7 @@ x-quorum-def:
       do
         set -e
         if [ -S $\${PRIVATE_CONFIG} ] && \\\\
-          [ \\"I'm up!\\" == \\"$$(wget --timeout $\${UDS_WAIT} -qO- --proxy off \${DOCKER_IP}$\${NODE_ID}:\${TESSERA_P2P_PORT:-9000}/upcheck)\\" ];
+          [ \\"I'm up!\\" == \\"$$(wget --timeout $\${UDS_WAIT} -qO- --proxy off txmanager$\${NODE_ID}:\${TESSERA_P2P_PORT:-9000}/upcheck)\\" ];
         then break
         else
           echo \\"Sleep $\${UDS_WAIT} seconds. Waiting for TxManager.\\"
@@ -542,7 +542,7 @@ x-quorum-def:
       NETWORK_ID=$$(cat $\${GENESIS_FILE} | grep chainId | awk -F \\" \\" '{print $$2}' | awk -F \\",\\" '{print $$1}')
       GETH_ARGS_raft=\\"--raft --raftport \${QUORUM_RAFT_PORT:-50400}\\"
       GETH_ARGS_istanbul=\\"--emitcheckpoints --istanbul.blockperiod 1 --mine --minerthreads 1 --syncmode full\\"
-      EXTRA_ARGS=\${QUORUM_GETH_ARGS:-}
+      EXTRA_ARGS=\\"\${QUORUM_GETH_ARGS:-}\\"
       geth --datadir $\${DDIR} init $\${GENESIS_FILE}
       geth \\\\
         --identity node$\${NODE_ID}-\${QUORUM_CONSENSUS:-istanbul} \\\\
@@ -802,7 +802,7 @@ x-quorum-def:
       do
         set -e
         if [ -S $\${PRIVATE_CONFIG} ] && \\\\
-          [ \\"I'm up!\\" == \\"$$(wget --timeout $\${UDS_WAIT} -qO- --proxy off \${DOCKER_IP}$\${NODE_ID}:\${TESSERA_P2P_PORT:-9000}/upcheck)\\" ];
+          [ \\"I'm up!\\" == \\"$$(wget --timeout $\${UDS_WAIT} -qO- --proxy off txmanager$\${NODE_ID}:\${TESSERA_P2P_PORT:-9000}/upcheck)\\" ];
         then break
         else
           echo \\"Sleep $\${UDS_WAIT} seconds. Waiting for TxManager.\\"
@@ -821,7 +821,7 @@ x-quorum-def:
       NETWORK_ID=$$(cat $\${GENESIS_FILE} | grep chainId | awk -F \\" \\" '{print $$2}' | awk -F \\",\\" '{print $$1}')
       GETH_ARGS_raft=\\"--raft --raftport \${QUORUM_RAFT_PORT:-50400}\\"
       GETH_ARGS_istanbul=\\"--emitcheckpoints --istanbul.blockperiod 1 --mine --minerthreads 1 --syncmode full\\"
-      EXTRA_ARGS=\${QUORUM_GETH_ARGS:-}
+      EXTRA_ARGS=\\"\${QUORUM_GETH_ARGS:-}\\"
       geth --datadir $\${DDIR} init $\${GENESIS_FILE}
       geth \\\\
         --identity node$\${NODE_ID}-\${QUORUM_CONSENSUS:-istanbul} \\\\
@@ -1046,7 +1046,7 @@ x-quorum-def:
       do
         set -e
         if [ -S $\${PRIVATE_CONFIG} ] && \\\\
-          [ \\"I'm up!\\" == \\"$$(wget --timeout $\${UDS_WAIT} -qO- --proxy off \${DOCKER_IP}$\${NODE_ID}:\${TESSERA_P2P_PORT:-9000}/upcheck)\\" ];
+          [ \\"I'm up!\\" == \\"$$(wget --timeout $\${UDS_WAIT} -qO- --proxy off txmanager$\${NODE_ID}:\${TESSERA_P2P_PORT:-9000}/upcheck)\\" ];
         then break
         else
           echo \\"Sleep $\${UDS_WAIT} seconds. Waiting for TxManager.\\"
@@ -1065,7 +1065,7 @@ x-quorum-def:
       NETWORK_ID=$$(cat $\${GENESIS_FILE} | grep chainId | awk -F \\" \\" '{print $$2}' | awk -F \\",\\" '{print $$1}')
       GETH_ARGS_raft=\\"--raft --raftport \${QUORUM_RAFT_PORT:-50400}\\"
       GETH_ARGS_istanbul=\\"--emitcheckpoints --istanbul.blockperiod 1 --mine --minerthreads 1 --syncmode full\\"
-      EXTRA_ARGS=\${QUORUM_GETH_ARGS:-}
+      EXTRA_ARGS=\\"\${QUORUM_GETH_ARGS:-}\\"
       geth --datadir $\${DDIR} init $\${GENESIS_FILE}
       geth \\\\
         --identity node$\${NODE_ID}-\${QUORUM_CONSENSUS:-istanbul} \\\\
@@ -1257,7 +1257,7 @@ x-quorum-def:
       do
         set -e
         if [ -S $\${PRIVATE_CONFIG} ] && \\\\
-          [ \\"I'm up!\\" == \\"$$(wget --timeout $\${UDS_WAIT} -qO- --proxy off \${DOCKER_IP}$\${NODE_ID}:\${TESSERA_P2P_PORT:-9000}/upcheck)\\" ];
+          [ \\"I'm up!\\" == \\"$$(wget --timeout $\${UDS_WAIT} -qO- --proxy off txmanager$\${NODE_ID}:\${TESSERA_P2P_PORT:-9000}/upcheck)\\" ];
         then break
         else
           echo \\"Sleep $\${UDS_WAIT} seconds. Waiting for TxManager.\\"
@@ -1276,7 +1276,7 @@ x-quorum-def:
       NETWORK_ID=$$(cat $\${GENESIS_FILE} | grep chainId | awk -F \\" \\" '{print $$2}' | awk -F \\",\\" '{print $$1}')
       GETH_ARGS_raft=\\"--raft --raftport \${QUORUM_RAFT_PORT:-50400}\\"
       GETH_ARGS_istanbul=\\"--emitcheckpoints --istanbul.blockperiod 1 --mine --minerthreads 1 --syncmode full\\"
-      EXTRA_ARGS=\${QUORUM_GETH_ARGS:-}
+      EXTRA_ARGS=\\"\${QUORUM_GETH_ARGS:-}\\"
       geth --datadir $\${DDIR} init $\${GENESIS_FILE}
       geth \\\\
         --identity node$\${NODE_ID}-\${QUORUM_CONSENSUS:-istanbul} \\\\

--- a/src/utils/pathUtils.js
+++ b/src/utils/pathUtils.js
@@ -1,4 +1,4 @@
-import { join, parse } from 'path'
+import { join, parse, posix } from 'path'
 import { isWin32 } from './execUtils'
 
 // C:\\ on windows, for example
@@ -26,4 +26,17 @@ export function removeTrailingSlash(path) {
 export function wrapScript(script) {
   // `./start.sh` in shell, just `start.cmd` in windows
   return isWin32() ? script : `./${script}`
+}
+
+// convert C:\folder\ to /c/folder/ for docker on windows
+export function unixifyPath(path) {
+  if(!isWin32()) {
+    return path
+  }
+  let unixifiedPath = path.replace(/\\/g, '/')
+  const matcher = unixifiedPath.match(/^(\w):(.*)$/)
+  if(matcher) {
+    return posix.join('/', matcher[1].toLowerCase(), matcher[2])
+  }
+  return unixifiedPath
 }


### PR DESCRIPTION
- Update ethers-js version
- use docker supplied txmanager1/2/etc hostname instead of the docker ip in starting healthcheck
- wraps EXTRA_ARGS in quotes, not sure exactly what changed to make this become necessary
- docker commands work better when using unix-style paths instead of windows (/c/folder/ vs C:\folder\), so we convert the path for the docker generate resources command only